### PR TITLE
Use Faraday::FlatParamsEncoder for category params

### DIFF
--- a/lib/v5/api_v5.rb
+++ b/lib/v5/api_v5.rb
@@ -38,7 +38,9 @@ module PagespeedInsights
 
     def make_request(uri_params)
       headers = { 'Accept': 'application/json' }
-      response = Faraday.get(@base_url, uri_params, headers)
+      response = Faraday.get(@base_url, uri_params, headers) do |req|
+        req.options.params_encoder = Faraday::FlatParamsEncoder
+      end
       @status = response.status
       @headers = response.headers
       @body = response.body


### PR DESCRIPTION
Sorry, I had this backwards at first.

The actual fix is using Faraday's `FlatParamsEncoder` for using the `category` params multiple times, as detailed in https://stackoverflow.com/questions/64149796/want-to-pass-multiple-enum-values-for-pagespeed-insights-api

Closes #3 